### PR TITLE
fix argument parsing for configuration directory. 

### DIFF
--- a/JobSubmission/6_OptimalNumberOfStates.sh
+++ b/JobSubmission/6_OptimalNumberOfStates.sh
@@ -113,9 +113,6 @@ shift $((OPTIND-1))
 ##    SET UP    ##
 ## ============ ##
 
-# Configuration files are required for file paths and log file management
-configuration_directory=$1
-
 source "${configuration_directory}/FilePaths.txt" || \
 { echo "The configuration file does not exist in the specified location: \
 ${configuration_directory}"; exit 1; }


### PR DESCRIPTION
## Description
After argument parsing section, there was still an assignment line for configuration_directory. But because all arguments were removed after arg parsing section, this set the variable to "". Which resulted in early termination as config files are not in the root of the system (hopefully).

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation