### PR TITLE
Name errors

### DIFF
--- a/JobSubmission/6_OptimalNumberOfStates.sh
+++ b/JobSubmission/6_OptimalNumberOfStates.sh
@@ -113,9 +113,6 @@ shift $((OPTIND-1))
 ##    SET UP    ##
 ## ============ ##
 
-# Configuration files are required for file paths and log file management
-configuration_directory=$1
-
 source "${configuration_directory}/FilePaths.txt" || \
 { echo "The configuration file does not exist in the specified location: \
 ${configuration_directory}"; exit 1; }

--- a/JobSubmission/6_OptimalNumberOfStates.sh
+++ b/JobSubmission/6_OptimalNumberOfStates.sh
@@ -230,9 +230,9 @@ for model_number in ${model_sizes}; do
         "the existence of this state assignment file"; finishing_statement 1; }
     fi
 
-    echo "Running SimilarEmssions.R for: ${model_number} states..."
+    echo "Running SimilarEmissions.R for: ${model_number} states..."
 
-    Rscript SimilarEmssions.R "${configuration_directory}/config.R" \
+    Rscript SimilarEmissions.R "${configuration_directory}/config.R" \
     "${emissions_file}" \
     "${output_directory}/Euclidean_distances" \
     FALSE

--- a/JobSubmission/6_OptimalNumberOfStates.sh
+++ b/JobSubmission/6_OptimalNumberOfStates.sh
@@ -190,7 +190,7 @@ sort -gr)
 
 
 output_directory="${OPTIMUM_STATES_DIR}\
-/BinSize_${bin_size}_SampleSize_${sample_size}_MaxModelSize_${model_number}"
+/BinSize_${bin_size}_SampleSize_${sample_size}_MaxModelSize_${model_sizes[-1]}"
 
 mkdir -p "${output_directory}"
 rm -f "${output_directory}"/*

--- a/JobSubmission/6_OptimalNumberOfStates.sh
+++ b/JobSubmission/6_OptimalNumberOfStates.sh
@@ -193,7 +193,7 @@ output_directory="${OPTIMUM_STATES_DIR}\
 /BinSize_${bin_size}_SampleSize_${sample_size}_MaxModelSize_${model_sizes[-1]}"
 
 mkdir -p "${output_directory}"
-rm -f "${output_directory}"/*
+rm -f "${output_directory:?}"/*
 
 module purge
 module load R/4.2.1-foss-2022a

--- a/Rscripts/FlankingStates.R
+++ b/Rscripts/FlankingStates.R
@@ -92,7 +92,7 @@ downstream_flank <- function(transitions_data, state) {
 ##   MAIN   ##
 ## ======== ##
 
-model_size <- numrows(transition_data)
+model_size <- nrow(transition_data)
 
 list_of_states <- seq_along(1:model_size)
 

--- a/Rscripts/IsolationScores.R
+++ b/Rscripts/IsolationScores.R
@@ -157,7 +157,7 @@ isolation_scores_output <-
 
 # This is purely so that the output text file is easier to read
 sorted_isolation_scores <-
-  isolation_scores_output[order(isolation_scores_output$states), ]
+  isolation_scores_output[order(isolation_scores_output$state), ]
 
 ## =========== ##
 ##   OUTPUTS   ##


### PR DESCRIPTION
## Description
There are lots of errors with spelling variable names incorrectly from PR #4. This fixes some of them (specifically for r scripts).

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation