### PR TITLE
Optimal states bug fixes

### DIFF
--- a/JobSubmission/6_OptimalNumberOfStates.sh
+++ b/JobSubmission/6_OptimalNumberOfStates.sh
@@ -191,8 +191,9 @@ output_directory="${OPTIMUM_STATES_DIR}\
 /BinSize_${bin_size}_SampleSize_${sample_size}_MaxModelSize_${model_sizes[0]}"
 
 
-mkdir -p "${output_directory}"
-rm -f "${output_directory:?}"/*
+mkdir -p "${output_directory}/Euclidean_distances"
+mkdir -p "${output_directory}/Flanking_states"
+mkdir -p "${output_directory}/Isolation_scores"
 
 module purge
 module load R/4.2.1-foss-2022a

--- a/Rscripts/FlankingStates.R
+++ b/Rscripts/FlankingStates.R
@@ -97,11 +97,13 @@ model_size <- nrow(transitions_data)
 
 list_of_states <- seq_along(1:model_size)
 
-list_of_upstream_flanks <-
-  mapply(upstream_flank, transitions_data, list_of_states)
+list_of_upstream_flanks <- 
+  sapply(list_of_states,
+         function(state) upstream_flank(transitions_data, state))
 
-list_of_downstream_flanks <-
-  mapply(downstream_flank, transitions_data, list_of_states)
+list_of_downstream_flanks <- 
+  sapply(list_of_states,
+         function(state) downstream_flank(transitions_data, state))
 
 flanking_states_table <-
   data.frame(state = list_of_states,


### PR DESCRIPTION
## Description
This fixes the following error messages from ocurring when running 6_OptimalNumberOfStates.sh:

Error in setwd(output_file_path) : cannot change working directory
Execution halted
Error in transitions_data[, state] : incorrect number of dimensions
Calls: mapply -> <Anonymous>


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation