### PR TITLE
Redundancy metrics bug fixes

### DIFF
--- a/JobSubmission/6_OptimalNumberOfStates.sh
+++ b/JobSubmission/6_OptimalNumberOfStates.sh
@@ -252,6 +252,7 @@ for model_number in "${model_sizes[@]}"; do
     Rscript IsolationScores.R "${configuration_directory}/config.R" \
     "${state_assignment_file}" \
     "${output_directory}/Isolation_scores" \
+    "${model_number}" \
     100 
 
 

--- a/Rscripts/FlankingStates.R
+++ b/Rscripts/FlankingStates.R
@@ -67,25 +67,23 @@ upstream_flank <- function(transitions_data, state) {
 
   # We don't want to factor in the probability of the upstream bin being
   # the same as the selected state, so we remove this value.
-  state_column_excluding_self <-
-    subset(state_column, subset = seq_along(state_column) != state)
+  state_column[state] <- NA
 
   # The state that has the maximum probability of transitioning towards
   # the selected state is our most likely upstream flank
-  return(which(max(state_column_excluding_self) == state_column))
+  return(which.max(state_column))
 }
 
 downstream_flank <- function(transitions_data, state) {
   # Rows give the transition probability of travelling from our selected state
   # to some other state
   state_row <- transitions_data[state, ]
-
-  state_row_excluding_self <-
-    subset(state_row, subset = seq_along(state_row) != state)
-
+  
+  state_row[state] <- NA
+  
   # The state that has the maximum probability of being transitioned to
   # from the selected state is our most likely downstream flank
-  return(which(max(state_row_excluding_self) == state_row))
+  return(which.max(state_row))
 }
 
 ## ======== ##
@@ -107,8 +105,8 @@ list_of_downstream_flanks <-
 
 flanking_states_table <-
   data.frame(state = list_of_states,
-             likeliest_upstream_flank = unlist(list_of_upstream_flanks),
-             likeliest_downstream_flank = unlist(list_of_downstream_flanks))
+             likeliest_upstream_flank = list_of_upstream_flanks,
+             likeliest_downstream_flank = list_of_downstream_flanks)
 
 ## =========== ##
 ##   OUTPUTS   ##

--- a/Rscripts/IsolationScores.R
+++ b/Rscripts/IsolationScores.R
@@ -20,7 +20,8 @@
 ## $1 -> Location of configuation file                            ||
 ## $2 -> State assignments file                                   ||
 ## $3 -> Output file path                                         ||
-## $4 -> Sample size for isolation score                          ||
+## $4 -> Size of the model                                        ||
+## $5 -> Sample size for isolation score                          ||
 ## ============================================================== ##
 ## OUTPUTS:                                                       ||
 ## Text file containing isolation scores for each state           ||
@@ -38,7 +39,8 @@ arguments <- commandArgs(trailingOnly = TRUE)
 config_file_location <- arguments[1]
 state_assignments_file <- arguments[2]
 output_file_path <- arguments[3]
-isolation_sample_size <- as.numeric(arguments[4])
+model_size <- as.numeric(arguments[4])
+isolation_sample_size <- as.numeric(arguments[5])
 
 source(config_file_location)
 

--- a/Rscripts/SimilarEmissions.R
+++ b/Rscripts/SimilarEmissions.R
@@ -92,7 +92,7 @@ setwd(output_file_path)
 
 output_file_name <- paste0("Euclidean_distances_model-", model_size, ".txt")
 
-write.table(flanking_states_table,
+write.table(euclidean_distances_table,
             output_file_name,
             row.names = FALSE)
 


### PR DESCRIPTION
## Description
Fix the following error messages:

Error in is.data.frame(x) : object 'flanking_states_table' not found
Calls: write.table -> is.data.frame
Execution halted
Error in data.frame(state = list_of_states, likeliest_upstream_flank = unlist(list_of_upstream_flanks),  : 
  arguments imply differing number of rows: 15, 0
Execution halted
Error in paste0("Isolation_Scores_model-", model_size, ".txt") : 
  object 'model_size' not found
Execution halted


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
