### PR TITLE
Fix file finding bug in Execute_redundancy_metrics.sh

### DIFF
--- a/supplementary/Redundancy_Threshold_Optimisation/JobSubmission/Execute_Redundancy_Metrics.sh
+++ b/supplementary/Redundancy_Threshold_Optimisation/JobSubmission/Execute_Redundancy_Metrics.sh
@@ -206,11 +206,11 @@ find "${model_file_dir}" \
 )
 
 emissions_file=$(\
-find "${MODEL_DIR}" -name "emissions*${model_size}.txt*" \
+find "${MODEL_DIR}" -name "emissions*${model_size}_${seed}.txt*" \
 )
 
 transitions_file=$(\
-find "${MODEL_DIR}" -name "transitions*${model_size}.txt*" \
+find "${MODEL_DIR}" -name "transitions*${model_size}_${seed}.txt*" \
 )
 
 if [[ -z "$state_assignment_file" ]]; then


### PR DESCRIPTION
## Description
This pull request will fix a bug where files were not found due to the existence of the seed in the file names

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Checklist:
- [x] My code is consistent in style with the rest of ChromOptomise
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
