### PR TITLE
fix isolation scores

### DIFF
--- a/supplementary/Redundancy_Threshold_Optimisation/JobSubmission/Execute_Redundancy_Metrics.sh
+++ b/supplementary/Redundancy_Threshold_Optimisation/JobSubmission/Execute_Redundancy_Metrics.sh
@@ -241,6 +241,7 @@ echo "Running IsolationScores.R for: ${model_size} states..."
 Rscript IsolationScores.R "${configuration_directory}/config.R" \
 "${state_assignment_file}" \
 "${model_file_dir}/Isolation_scores" \
+"${model_size}" \
 100 
 
 


### PR DESCRIPTION
## Description
This pull request will the model size was not previously being parsed resulting in the incorrect model size (always 100)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update

## Checklist:
- [ ] My code is consistent in style with the rest of ChromOptomise
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
