### PR TITLE
refactor: use module names specified by users

### DIFF
--- a/JobSubmission/1_BinarizeFiles.sh
+++ b/JobSubmission/1_BinarizeFiles.sh
@@ -104,7 +104,7 @@ rm -rf "${BINARY_DIR}/BinSize_${BIN_SIZE}"
 mkdir -p "${BINARY_DIR}/BinSize_${BIN_SIZE}"
 
 module purge
-module load Java
+module load "${JAVA_MODULE}"
 
 if [[ -s "${bam_CellMarkFileTable}" ]]; then
     echo "Binarizing bam files found in: "\

--- a/JobSubmission/2_batch_CreateIncrementalModels.sh
+++ b/JobSubmission/2_batch_CreateIncrementalModels.sh
@@ -135,7 +135,7 @@ fi
 ## ===================== ##
 
 module purge
-module load Java
+module load "${JAVA_MODULE}"
 
 sequence=$(\
 seq "$starting_number_of_states" "$states_increment" "$ending_number_of_states"\

--- a/JobSubmission/3_OptimalNumberOfStates.sh
+++ b/JobSubmission/3_OptimalNumberOfStates.sh
@@ -95,7 +95,7 @@ mkdir -p \
     "${output_directory}/Isolation_scores"
 
 module purge
-module load R/4.2.1-foss-2022a
+module load "${R_MODULE}"
 
 cd "${RSCRIPTS_DIR}" || \
 { >&2 echo "ERROR: [\${RSCRIPTS_DIR} - ${RSCRIPTS_DIR}] doesn't exist, \

--- a/JobSubmission/4_ReferenceLDSCore.sh
+++ b/JobSubmission/4_ReferenceLDSCore.sh
@@ -124,7 +124,7 @@ finishing_statement 1; }
 ## ---------------------- ##
 
 module purge
-module load R/4.2.1-foss-2022a
+module load "${R_MODULE}"
 
 Rscript BinarytoBed.R \
     <(zcat "${binary_files}") \
@@ -141,7 +141,7 @@ Rscript BimtoBed.R \
 ## ----------------------------------- ##
 
 module purge
-module load BEDTools/2.29.2-GCC-9.3.0
+module load "${BEDTOOLS_MODULE}"
 
 bedtools intersect -wb \
     -a "${temporary_directory}/SNP_positions-${chromosome}.bed" \
@@ -170,7 +170,7 @@ bedtools intersect -wb \
 ## ----------------------- ##
 
 module purge
-module load R/4.2.1-foss-2022a
+module load "${R_MODULE}"
 
 baseline_annot="${LD_BASELINE_DIR}/baselineLD.${chromosome}.annot.gz"
 

--- a/JobSubmission/5_PartitionedHeritability.sh
+++ b/JobSubmission/5_PartitionedHeritability.sh
@@ -110,7 +110,7 @@ done
 
 conda deactivate
 module purge
-module load R/4.2.1-foss-2022a
+module load "${R_MODULE}"
 
 Rscript "${RSCRIPTS_DIR}/HeritabilityPlots.R" \
     <(find "${ld_directory}/heritability" -name "*.results") \

--- a/Setup/Config.txt
+++ b/Setup/Config.txt
@@ -55,6 +55,20 @@ export MAXTIME_3=02:00:00
 export MAXTIME_4=02:30:00
 export MAXTIME_5=03:00:00
 
+## ============ ##
+##   SOFTWARE   ##
+## ============ ##
+
+# Assuming the system you are using uses modules (which is highly common
+# among HPCs in my limited experience), you can specify the modules to load
+# using the variables below
+
+# If your HPC doesn't have a module for these, it is better to remove instances
+# of `module load` commands using either `sed` or the setup script.
+
+BEDTOOLS_MODULE=
+R_MODULE=
+JAVA_MODULE=
 
 ## =============== ##
 ##   DIRECTORIES   ##

--- a/supplementary/Recreate_Transition_Heatmap/JobSubmission/Recreate_Transition_Heatmap.sh
+++ b/supplementary/Recreate_Transition_Heatmap/JobSubmission/Recreate_Transition_Heatmap.sh
@@ -46,7 +46,7 @@ if [[ $# -ne 3 ]]; then usage; fi
 ## ======== ##
 
 module purge
-module load R/4.2.1-foss-2022a
+module load "${R_MODULE}"
 
 Rscript \
     "${RSCRIPTS_DIR}/RecreateTransitionMatrix.R" \

--- a/supplementary/Redundancy_Threshold_Optimisation/JobSubmission/Execute_Redundancy_Metrics.sh
+++ b/supplementary/Redundancy_Threshold_Optimisation/JobSubmission/Execute_Redundancy_Metrics.sh
@@ -87,7 +87,7 @@ fi
 ## ======== ##
 
 module purge
-module load R/4.2.1-foss-2022a
+module load "${R_MODULE}"
 
 cd "${RSCRIPTS_DIR}" || \
 { >&2 echo "ERROR: make sure [\${RSCRIPTS_DIR} - ${RSCRIPTS_DIR}] \

--- a/supplementary/Redundancy_Threshold_Optimisation/JobSubmission/Generate_Big_Model.sh
+++ b/supplementary/Redundancy_Threshold_Optimisation/JobSubmission/Generate_Big_Model.sh
@@ -89,7 +89,7 @@ finishing_statement 1; }
 echo "Learning a model with ${model_size} states and random seed: ${seed}..."
 
 module purge
-module load Java
+module load "${JAVA_MODULE}"
 
 cd "${BIG_MODELS_DIR}" || \
 { >&2 echo "ERROR: [\${BIG_MODELS_DIR} - ${BIG_MODELS_DIR}] \


### PR DESCRIPTION
Instead of blanket removing them in setup, users can define their own verisons of each peice of software (via modules)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Documentation update

## Checklist:
- [x] My code is consistent in style with the rest of ChromOptimise
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
