### PR TITLE
feat: Upgrade heatmap plots

### DIFF
--- a/Rscripts/HeritabilityPlots.R
+++ b/Rscripts/HeritabilityPlots.R
@@ -211,8 +211,12 @@ create_enrichment_heatmap <- function(results_files,
     Enrichment = dplyr::if_else(Enrichment > 100, NA_real_, Enrichment)
   )
 
-  negative_palette <- c("red", "pink")
-  postitive_palette <- c("lightgreen", "darkgreen")
+  # we mainly care about how the enrichment compares to 1. So we scale the
+  # colours of our heatmap around this value
+  max_enrichment <- max(heatmap_data[["Enrichment"]], na.rm = TRUE)
+  colour_palette <- c("yellow", "red", "grey")
+  colour_scale <- c(0, 1, max_enrichment) / max_enrichment
+
   enrichment_heatmap <-
     ggplot(heatmap_data, aes(
       x = gwas_trait,
@@ -220,11 +224,10 @@ create_enrichment_heatmap <- function(results_files,
       fill = Enrichment,
     )) +
     geom_tile(color = "black") +
-    scale_fill_gradient2(
-      low = negative_palette,
-      high = postitive_palette,
-      midpoint = 0,
-      na.value = "pink"
+    scale_fill_gradientn(
+      colors = colour_palette,
+      values = colour_scale,
+      na.value = "grey"
     ) +
     geom_text(
       aes(

--- a/Rscripts/HeritabilityPlots.R
+++ b/Rscripts/HeritabilityPlots.R
@@ -203,9 +203,12 @@ create_enrichment_heatmap <- function(results_files,
     Enrichment_p = -log10(Enrichment_p)
   )
 
+  # Enrichment values greater than 100 have always been within annotations
+  # that have lots of negative enrichments in my experience.
   heatmap_data <- dplyr::mutate(
     heatmap_data,
-    Enrichment = dplyr::if_else(Enrichment < 0, NA_real_, Enrichment)
+    Enrichment = dplyr::if_else(Enrichment < 0, NA_real_, Enrichment),
+    Enrichment = dplyr::if_else(Enrichment > 100, NA_real_, Enrichment)
   )
 
   negative_palette <- c("red", "pink")

--- a/Rscripts/HeritabilityPlots.R
+++ b/Rscripts/HeritabilityPlots.R
@@ -214,8 +214,8 @@ create_enrichment_heatmap <- function(results_files,
   # we mainly care about how the enrichment compares to 1. So we scale the
   # colours of our heatmap around this value
   max_enrichment <- max(heatmap_data[["Enrichment"]], na.rm = TRUE)
-  colour_palette <- c("yellow", "red", "grey")
-  colour_scale <- c(0, 1, max_enrichment) / max_enrichment
+  colour_palette <- c("yellow", "pink", "red", "grey")
+  colour_scale <- c(0, 1, max_enrichment - 0.5, max_enrichment) / max_enrichment
 
   enrichment_heatmap <-
     ggplot(heatmap_data, aes(

--- a/documentation/docs/ChromOptimise/Pipeline-Explanation/LDSC/HeritabilityPlots.md
+++ b/documentation/docs/ChromOptimise/Pipeline-Explanation/LDSC/HeritabilityPlots.md
@@ -24,11 +24,11 @@ input data).
 
 ## Interpretation
 
-The colour palette of the heatmap is such that higher enrichment values
-are a darker green and lower enrichment values are closer to white/light green.
-Any negative enrichment is given with a pink box.
-The actual values for the enrichment heatmap are also given and all information
-is printed to a csv file.
+The colour palette of the heatmap is such that higher enrichment values (>1)
+are redish and lower enrichment values (<1) are yellowish. Any negative
+enrichment or ridiculously high enrichment (>100) is given with a grey box. The
+actual values for the enrichment heatmap are also given in the outputted csv
+file (Enrichments.csv)
 
 Enrichment is defined as:
 > The proportion of SNP heritability explained divided by the proportion of
@@ -38,17 +38,17 @@ In general you should ignore negative enrichment as
 this usually stems from negative heritability (which is nonsensicle).For 
 positive values however, the following interpretations can be made:
 
-- An enrichment value greater than 1 implies that the regions defined by the
-annotation explain a high proportion of snp heritability considering they have 
-a relatively small percentage of all snps.
-- An enrichment value less than 1 implies the opposite. Regions defined by the
-annotaiton generally explain very little snp heritabilty considering the
-total percentage of SNPs they account for.
+- An enrichment value greater than 1 (redish) implies that the regions defined
+  by the annotation explain a high proportion of snp heritability considering
+  they have a relatively small percentage of all snps.
+- An enrichment value less than 1 (yellowish) implies the opposite. Regions
+  defined by the annotaiton generally explain very little snp heritabilty
+  considering the total percentage of SNPs they account for.
 - An enrichment value close to 1 is what you would see for a category like
-base. Base is a category that every SNP falls into (to ensure all SNPs are
-accounted for). Base therefore explains 100% of SNP heritability and contains
-100% of all SNPs, resulting in an enrichment of 1. An enrichment of 1 is not
-a significant result of partitioned heritability.
+  base. Base is a category that every SNP falls into (to ensure all SNPs are
+  accounted for). Base therefore explains 100% of SNP heritability and contains
+  100% of all SNPs, resulting in an enrichment of 1. An enrichment of 1 is not
+  a significant result of partitioned heritability.
 
 ### p-value thresholds
 

--- a/documentation/docs/ChromOptimise/Pipeline-Explanation/LDSC/HeritabilityPlots.md
+++ b/documentation/docs/ChromOptimise/Pipeline-Explanation/LDSC/HeritabilityPlots.md
@@ -52,7 +52,7 @@ positive values however, the following interpretations can be made:
 
 ### p-value thresholds
 
-A baseline value of 0.01 was chosen for a p-value threshold. This was arbitrary
+A baseline value of 0.05 was chosen for a p-value threshold. This was arbitrary
 and the user is free to change this in the associated script 
 (`HeritabilityPlots.R`). However, this p-value threshold is under jeopardy due
 to the high number of hypotheses that are being tested at once. If you are


### PR DESCRIPTION
## Description
This pull request will add a colour blind friendly palette to heatmap and make the colour scale go from:
0 - 1 -> yellowish
1 - max-value -> redish
na-values -> grey

It also considers *very high* enrichments to be nonsensical now (and converts them to NA aswell).
The top end of the enrichments are coloured grey in the heatmap anyway.

The current code will make heatmaps with every enrichment value below 1 look bad. But I highly doubt this will happen unless the user learns a 2 state model and only has one epigenetic mark (which defeats the purpose of using ChromHMM).

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Checklist:
- [x] My code is consistent in style with the rest of ChromOptimise
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
