### PR TITLE
feat: Add ldsc window size customisability 

### DIFF
--- a/JobSubmission/4_ReferenceLDSCore.sh
+++ b/JobSubmission/4_ReferenceLDSCore.sh
@@ -205,7 +205,7 @@ python \
     "${LD_SOFTWARE_DIR}/ldsc.py" \
     --l2 \
     --bfile      "${LD_PLINK_DIR}/${plink_prefix}${chromosome}" \
-    --ld-wind-cm 1 \
+    --ld-wind-cm "${LD_WINDOW_SIZE}" \
     --annot      "${output_directory}/annotation/ChromOptimise.${chromosome}.annot" \
     --out        "${output_directory}/annotation/ChromOptimise.${chromosome}"
 

--- a/Setup/Config.txt
+++ b/Setup/Config.txt
@@ -45,6 +45,11 @@ export OPTIMUM_NUMBER_OF_STATES=
 # arbitrary of course.
 export SIGNIFICANCE=0.05
 
+# This is optional, if LDSC is giving lots of negative partioned heritability
+# (you will see a WARNING.txt in the LDSC directory), it is suggested to
+# reduce the window size (default is 1 centimorgan)
+export LD_WINDOW_SIZE=1
+
 # SLURM requires a maximum wall time, defaults usually work for smaller 
 # datasets (<= 4 marks). For an idea of what to use, please see the Processing
 # Times page on the wiki.

--- a/documentation/docs/ChromOptimise/Pipeline-Explanation/LDSC/HeritabilityPlots.md
+++ b/documentation/docs/ChromOptimise/Pipeline-Explanation/LDSC/HeritabilityPlots.md
@@ -114,7 +114,7 @@ enriched than not?
 - Are the negative enrichment values somewhat evenly distributed throughout the
 heatmap?
   - If so, then make the window size smaller in `7_ReferenceLDSCore.sh`. Change
-  the flag `--ld-wind-cm 1` to have a smaller value than 1.
+  the value in $LD_WINDOW_SIZE (config) to have a smaller value than 1.
   - This line can be found in the reference LD scores section of the script
 
 If problems continue to persist, there may be a problem with the dataset that


### PR DESCRIPTION
## Description
This pull request will add $LD_WINDOW_SIZE to the config, allowing the user to change the value used for 
`--ld-wind-cm`
This allegedly helps with some models giving lots of negative partitioned heritability

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update

## Checklist:
- [x] My code is consistent in style with the rest of ChromOptimise
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
